### PR TITLE
Change default polyline opague

### DIFF
--- a/www/Polyline.js
+++ b/www/Polyline.js
@@ -76,7 +76,8 @@ var Polyline = function (map, polylineOptions, _exec) {
   self.on("strokeColor_changed", function () {
     if (self._isRemoved) return;
     var color = self.get("strokeColor");
-    self.exec.call(self, null, self.errorHandler, self.getPluginName(), 'setStrokeColor', [self.getId(), common.HTMLColor2RGBA(color, 0.75)]);
+    self.exec.call(self, null, self.errorHandler, self.getPluginName(), 'setStrokeColor', [self.getId(), common.HTMLColor2RGBA(color)]);
+    // self.exec.call(self, null, self.errorHandler, self.getPluginName(), 'setStrokeColor', [self.getId(), common.HTMLColor2RGBA(color, 0.75)]);
   });
 
 };


### PR DESCRIPTION
Changed the default opacity from 0.75 to 1.

Normally polylines are a solid black in the PCI Client app. On iOS if I were to select and polyline and then deselect it, the color would change to a lighter black. This is because of the 0.75 opacity.

After attempting to solve the problem without editting the plugin, I ended up re-introducing an old bug with Android. For some reason when you specify the alpha value on Android, the polylines aren't displayed on the map. I don't know why this happens; but, the solution was to pass in an RGB value instead of RGBA. 
In otherwords, use the default opacity. 
I still don't know why sometimes it had opacity 1 and other times it had opacity 0.75; but, polyline opacity should really be defined by the user, not the plugin.