### PR TITLE
fix: Stop intercepting cordova back button logic and instead simply u…

### DIFF
--- a/www/pluginInit.js
+++ b/www/pluginInit.js
@@ -121,49 +121,15 @@ function pluginInit() {
   //--------------------------------------------
   // Hook the backbutton of Android action
   //--------------------------------------------
-  var anotherBackbuttonHandler = null;
 
   function onBackButton(e) {
-
     // Check DOM tree for new page
     cordova.fireDocumentEvent('plugin_touch', {
       force: true
     });
-
-    if (anotherBackbuttonHandler) {
-      // anotherBackbuttonHandler must handle the page moving transaction.
-      // The plugin does not take care anymore if another callback is registered.
-      anotherBackbuttonHandler(e);
-    } else {
-      cordova_exec(null, null, 'CordovaGoogleMaps', 'backHistory', []);
-    }
   }
 
   document.addEventListener('backbutton', onBackButton);
-
-  var _org_addEventListener = document.addEventListener;
-  var _org_removeEventListener = document.removeEventListener;
-  document.addEventListener = function (eventName, callback) {
-    var args = Array.prototype.slice.call(arguments, 0);
-    if (eventName.toLowerCase() !== 'backbutton') {
-      _org_addEventListener.apply(this, args);
-      return;
-    }
-    if (!anotherBackbuttonHandler) {
-      anotherBackbuttonHandler = callback;
-    }
-  };
-  document.removeEventListener = function (eventName, callback) {
-    var args = Array.prototype.slice.call(arguments, 0);
-    if (eventName.toLowerCase() !== 'backbutton') {
-      _org_removeEventListener.apply(this, args);
-      return;
-    }
-    if (anotherBackbuttonHandler === callback) {
-      anotherBackbuttonHandler = null;
-    }
-  };
-
 }
 
 module.exports = pluginInit;


### PR DESCRIPTION
The act of a singular back listener doesn't work and doesn't conform to the `addEventListener` API which can accept multiple listeners.

This breaks because individual screens are responsible for managing their listeners, however the navgiating screen mounts before the old screen unmounts.