### PR TITLE
Created a new config variable, replacing the old GOOGLE_MAPS_PLAY_SER…

### DIFF
--- a/src/android/frameworks/pgm-custom.gradle
+++ b/src/android/frameworks/pgm-custom.gradle
@@ -39,7 +39,8 @@ android {
   Properties props = new Properties()
   def isKeyFound = 0
   def useBetaSdk = 0
-  props.setProperty("GOOGLE_MAPS_PLAY_SERVICES_VERSION", "16.0.0");
+  props.setProperty("GOOGLE_MAPS_PLAY_SERVICES_GMS_VERSION", "18.2.0");
+  props.setProperty("GOOGLE_MAPS_PLAY_SERVICES_LOCATION_VERSION", "21.0.1");
   props.setProperty("ANDROID_SUPPORT_V4_VERSION", "27.1.1");
   props.setProperty("GOOGLE_MAPS_ANDROID_SDK", "");
 
@@ -51,8 +52,10 @@ android {
       isKeyFound = 1
       props.setProperty(name, value)
     }
-    if (name == "GOOGLE_MAPS_PLAY_SERVICES_VERSION" ||
-        name == "ANDROID_SUPPORT_V4_VERSION") {
+    if (name == "GOOGLE_MAPS_PLAY_SERVICES_GMS_VERSION" ||
+        name == "ANDROID_SUPPORT_V4_VERSION" ||
+        name == "GOOGLE_MAPS_PLAY_SERVICES_LOCATION_VERSION"
+    ) {
       props.setProperty(name, value)
     }
     if (name == "GOOGLE_MAPS_ANDROID_SDK") {
@@ -84,13 +87,15 @@ android {
     }
   }
 
-  def PLAY_SERVICES_VERSION = props.get("GOOGLE_MAPS_PLAY_SERVICES_VERSION")
+  def PLAY_SERVICES_GMS_VERSION = props.get("GOOGLE_MAPS_PLAY_SERVICES_GMS_VERSION")
+  def PLAY_SERVICES_LOCATION_VERSION = props.get("GOOGLE_MAPS_PLAY_SERVICES_LOCATION_VERSION")
   def ANDROID_SUPPORT_V4_VERSION = props.get("ANDROID_SUPPORT_V4_VERSION")
-  println("---->PLAY_SERVICES_VERSION = ${PLAY_SERVICES_VERSION}")
+  println("---->PLAY_SERVICES_GMS_VERSION = ${PLAY_SERVICES_GMS_VERSION}")
+  println("---->PLAY_SERVICES_LOCATION_VERSION = ${PLAY_SERVICES_LOCATION_VERSION}")
   println("---->ANDROID_SUPPORT_V4_VERSION = ${ANDROID_SUPPORT_V4_VERSION}")
   dependencies {
-    implementation "com.google.android.gms:play-services-maps:${PLAY_SERVICES_VERSION}"
-    implementation "com.google.android.gms:play-services-location:${PLAY_SERVICES_VERSION}"
+    implementation "com.google.android.gms:play-services-maps:${PLAY_SERVICES_GMS_VERSION}"
+    implementation "com.google.android.gms:play-services-location:${PLAY_SERVICES_LOCATION_VERSION}"
     implementation "com.android.support:support-core-utils:${ANDROID_SUPPORT_V4_VERSION}"
   }
 


### PR DESCRIPTION
…VICES_VERSION which

was used to power the version pin for both google maps and location play services dependencies.

Problem is these 2 packages does not follow the same version scheme, it doesn't make sense for them to share the same variable. This will allow specific organizations to use a newer version without necessary updating the plugin itself.

Additionally, both the maps and location dependencies were updated to the current latest available.

# Pull request guide

Thank you for considering to improve this cordova-plugin-googlemaps.

When you create a pull request, please make it to **multiple_maps** branch instead of master branch.

Because **the multiple_maps branch is edge version**.

Thank you for your understanding.
