### PR TITLE
Updated Marker codebases to give control of the activation of the inf…

### DIFF
--- a/src/android/plugin/google/maps/PluginMap.java
+++ b/src/android/plugin/google/maps/PluginMap.java
@@ -2289,16 +2289,16 @@ public class PluginMap extends MyPlugin implements OnMarkerClickListener,
           e.printStackTrace();
         }
         if (disableAutoPan) {
-          marker.showInfoWindow();
+          // marker.showInfoWindow();
           return true;
         } else {
-          marker.showInfoWindow();
+          // marker.showInfoWindow();
           return false;
         }
       }
     }
 
-    marker.showInfoWindow();
+    // marker.showInfoWindow();
     return true;
     //return false;
   }

--- a/src/ios/GoogleMaps/PluginMap.m
+++ b/src/ios/GoogleMaps/PluginMap.m
@@ -634,7 +634,7 @@
     NSString *markerId = [command.arguments objectAtIndex:0];
     GMSMarker *marker = [self.mapCtrl.objects objectForKey:markerId];
     if (marker != nil) {
-      self.mapCtrl.map.selectedMarker = marker;
+      // self.mapCtrl.map.selectedMarker = marker;
       self.mapCtrl.activeMarker = marker;
     }
 

--- a/src/ios/GoogleMaps/PluginMapViewController.m
+++ b/src/ios/GoogleMaps/PluginMapViewController.m
@@ -405,7 +405,7 @@
   if ([clusterId_markerId containsString:@"markercluster_"]) {
     if ([clusterId_markerId containsString:@"-marker_"]) {
       //NSLog(@"--->activeMarker = %@", marker.userData);
-      self.map.selectedMarker = marker;
+      // self.map.selectedMarker = marker;
       self.activeMarker = marker;
       NSString *markerTag = [NSString stringWithFormat:@"%@", marker.userData];
       if ([markerTag hasPrefix:@"markercluster_"]) {
@@ -430,7 +430,7 @@
     [self execJS:@"javascript:if(window.cordova){cordova.fireDocumentEvent('plugin_touch', {});}"];
     [self triggerMarkerEvent:@"marker_click" marker:marker];
     //NSLog(@"--->activeMarker = %@", marker.userData);
-    self.map.selectedMarker = marker;
+    // self.map.selectedMarker = marker;
     self.activeMarker = marker;
   }
 

--- a/www/Marker.js
+++ b/www/Marker.js
@@ -21,6 +21,8 @@ var Marker = function(map, markerOptions, _exec, extras) {
     self.set('position', markerOptions.position);
   }
 
+  self.set('shouldShowInfoWindow', false);
+
   //-----------------------------------------------
   // Sets event listeners
   //-----------------------------------------------
@@ -313,11 +315,17 @@ Marker.prototype.setRotation = function(rotation) {
 Marker.prototype.getRotation = function() {
   return this.get('rotation');
 };
+Marker.prototype.setShouldShowInfoWindow = function(shouldShow) {
+  this.set('shouldShowInfoWindow', shouldShow);
+};
+Marker.prototype.getShouldShowInfoWindow = function() {
+  return this.get('shouldShowInfoWindow');
+};
 Marker.prototype.showInfoWindow = function() {
   var self = this;
   //if (!self.get('title') && !self.get('snippet') ||
   //    self.get('isInfoWindowVisible')) {
-  if (!self.get('title') && !self.get('snippet')) {
+  if (!self.get('shouldShowInfoWindow') || (!self.get('title') && !self.get('snippet'))) {
     return;
   }
   self.set('isInfoWindowVisible', true);


### PR DESCRIPTION
…o window to the user of the plugin.

Added shouldShowInfoWindow to the JavaScript Marker object. This attribute can be modified with set, but has an explicit setter and getter. This attribute defaults to false. If this attribute is false, JavaScript Marker will never call the showInfoWindow native API. If it's true, calls to this API will be allowed assuming other pre-existing conditions allow.

All automated activation of the info window has been disabled in the native iOS and Android codebases.


Additional details - 
This PR is for the Tracker plugin.

In current googlemaps plugin behaviour, when you tap on a Marker that has the title attribute set (or another specific attribute), the info window will appear and display that attribute.
I am not sure if the native sdks have this behaviour automatically set up and active but I was able to completely disable this behaviour purely by changing plugin code and behaviour implemented by the plugin codebase. So, as far this PR is concerned, the automatic displaying of the info window is completely provided by the googlemaps plugin.


Now why is this PR necessary?


In current production Tracker, when you tap on a Marker it will bring you to the edit item screen with that marker's item. When you return to the map screen (HomeScreen), the marker will be display with no additional windows or views. It's the exact same state as if you never clicked on a marker.
The info window is never displayed on current production Tracker.


In my dev builds for updating the Tracker app, the info window was being displayed. Sometimes it could be seen in a flash just before the app goes to edit item view. In addition, when I returned to the map screen, the info window would be left displayed on the marker with no way to dismiss it.


I didn't entirely investigate what changed, I do know if it's either something to do with how we use the plugin or plugin code.
For example, maybe current prod tracker completely destroys the marker when it leaves the view. Either way, this update is giving us control over whether or not the info window appears.


Which on that topic, plugin had multiple separated code paths that made efforts to display the info window in both native and javascript. 
I disabled the act of showing the info window in native code in all cases that I could get away with. iOS had 1 native code path which appeared to be necessary for the info window to be functional.

With this update, apps can configure markers to either allow or disallow showing the info window. It's a boolean configuration that uses the plugin's .set API with some setters. The tracker will have this disabled but I have tested the info windows with the setting enabled and it appears to work fine. Granted, my testing was not super thorough. I just verified it will appear in the expected code path.


So effectively, this PR will allow the Tracker app to match current production behaviour while fixing some flashes and buggy info window behaviour by removing the info window.
If we ever wanted info windows, we can still reintroduce them by enabling the setting.


I do not plan to PR this into the mapsplugin parent repo.
