### PR TITLE
Increased native API call limit from 10 to 100.

### DIFF
--- a/www/commandQueueExecutor.js
+++ b/www/commandQueueExecutor.js
@@ -9,7 +9,7 @@ var commandQueue = [];
 var _isWaitMethod = null;
 var _isExecuting = false;
 var _executingCnt = 0;
-var MAX_EXECUTE_CNT = 10;
+var MAX_EXECUTE_CNT = 100;
 var _lastGetMapExecuted = 0;
 var _isResizeMapExecuting = false;
 


### PR DESCRIPTION

This update was a significant improvement in Tracker performance when returning to the map screen.
This improvement was only visible when adding new markers.