### PR TITLE
Refactor uses of the CDVCommandDelegateImpl private API and converted…

### DIFF
--- a/src/ios/GoogleMaps/PluginMap.m
+++ b/src/ios/GoogleMaps/PluginMap.m
@@ -639,7 +639,7 @@
     }
 
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-    [(CDVCommandDelegateImpl *)self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
   }];
 }
 

--- a/src/ios/GoogleMaps/PluginMarker.m
+++ b/src/ios/GoogleMaps/PluginMarker.m
@@ -73,7 +73,7 @@
     [createResult setObject:markerId forKey:@"__pgmId"];
 
     [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-      CDVCommandDelegateImpl *cmdDelegate = (CDVCommandDelegateImpl *)self.commandDelegate;
+      id<CDVCommandDelegate> cmdDelegate = self.commandDelegate;
       [self _create:markerId markerOptions:json callbackBlock:^(BOOL successed, id result) {
         CDVPluginResult* pluginResult;
 
@@ -255,7 +255,7 @@
       }
 
       CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-      [(CDVCommandDelegateImpl *)self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+      [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
   }];
 }
@@ -270,7 +270,7 @@
       self.mapCtrl.map.selectedMarker = nil;
       self.mapCtrl.activeMarker = nil;
       CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-      [(CDVCommandDelegateImpl *)self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+      [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
   }];
 }
@@ -295,7 +295,7 @@
     [json setObject:longitude forKey:@"lng"];
 
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:json];
-    [(CDVCommandDelegateImpl *)self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
   }];
 }
 
@@ -319,7 +319,7 @@
 
 
       CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-      [(CDVCommandDelegateImpl *)self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+      [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
   }];
 }
@@ -338,7 +338,7 @@
       marker.snippet = [command.arguments objectAtIndex:1];
 
       CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-      [(CDVCommandDelegateImpl *)self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+      [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
   }];
 }
@@ -358,7 +358,7 @@
       marker = nil;
 
       CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-      [(CDVCommandDelegateImpl *)self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+      [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
   }];
 }
@@ -424,7 +424,7 @@
     }
 
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-    [(CDVCommandDelegateImpl *)self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
   }];
 }
 
@@ -450,7 +450,7 @@
       } else {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
       }
-      [(CDVCommandDelegateImpl *)self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+      [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
 
   }];
@@ -470,7 +470,7 @@
       marker.opacity = [[command.arguments objectAtIndex:1] floatValue];
 
       CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-      [(CDVCommandDelegateImpl *)self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+      [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
   }];
 }
@@ -488,7 +488,7 @@
       marker.zIndex = [[command.arguments objectAtIndex:1] intValue];
 
       CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-      [(CDVCommandDelegateImpl *)self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+      [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
   }];
 }
@@ -507,7 +507,7 @@
       [marker setDraggable:isEnabled];
 
       CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-      [(CDVCommandDelegateImpl *)self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+      [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
   }];
 }
@@ -530,7 +530,7 @@
     NSLog(@"--->propertyId = %@", propertyId);
 
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-    [(CDVCommandDelegateImpl *)self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
   }];
 }
 
@@ -560,7 +560,7 @@
       [self.mapCtrl.objects setObject:properties forKey:propertyId];
 
       CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-      [(CDVCommandDelegateImpl *)self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+      [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
   }];
 }
@@ -582,7 +582,7 @@
       [marker setPosition:position];
 
       CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-      [(CDVCommandDelegateImpl *)self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+      [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
   }];
 }
@@ -601,7 +601,7 @@
       [marker setFlat: isFlat];
 
       CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-      [(CDVCommandDelegateImpl *)self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+      [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
   }];
 }
@@ -645,7 +645,7 @@
       [iconProperty setObject:[rgbColor parsePluginColor] forKey:@"iconColor"];
     }
 
-    CDVCommandDelegateImpl *cmdDelegate = (CDVCommandDelegateImpl *)self.commandDelegate;
+    id<CDVCommandDelegate> cmdDelegate = self.commandDelegate;
     [self setIcon_:marker iconProperty:iconProperty callbackBlock:^(BOOL successed, id resultObj) {
       CDVPluginResult* pluginResult;
       if (successed == NO) {
@@ -671,7 +671,7 @@
       [marker setRotation:degrees];
 
       CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-      [(CDVCommandDelegateImpl *)self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+      [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
   }];
 }
@@ -686,7 +686,7 @@
       GMSMarker *marker = [self.mapCtrl.objects objectForKey:markerId];
 
       NSString *animation = [command.arguments objectAtIndex:1];
-      CDVCommandDelegateImpl *cmdDelegate = (CDVCommandDelegateImpl *)self.commandDelegate;
+      id<CDVCommandDelegate> cmdDelegate = self.commandDelegate;
 
       [self setMarkerAnimation_:animation marker:marker callbackBlock:^(void) {
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];

--- a/src/ios/GoogleMaps/PluginMarkerCluster.m
+++ b/src/ios/GoogleMaps/PluginMarkerCluster.m
@@ -453,7 +453,7 @@ const int GEOCELL_GRID_SIZE = 4;
 - (void) endRedraw:(CDVInvokedUrlCommand*)command {
   NSLog(@"--->allResults = %@", self.allResults);
   CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:self.allResults];
-  [(CDVCommandDelegateImpl *)self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+      [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void) deleteProcess:(NSDictionary *) params  clusterId:(NSString *)clusterId{

--- a/src/ios/GoogleMaps/PluginUtil.h
+++ b/src/ios/GoogleMaps/PluginUtil.h
@@ -19,8 +19,6 @@
 #import <math.h>
 #import "IPluginProtocol.h"
 #import "PluginViewController.h"
-#import <Cordova/CDVCommandDelegate.h>
-#import <Cordova/CDVCommandDelegateImpl.h>
 
 typedef void (^MYCompletionHandler)(NSError *error);
 
@@ -47,10 +45,6 @@ typedef void (^MYCompletionHandler)(NSError *error);
 @interface UIImage (GoogleMapsPlugin)
 - (UIImage*)imageByApplyingAlpha:(CGFloat) alpha;
 - (UIImage *)resize:(CGFloat)width height:(CGFloat)height;
-@end
-
-@interface CDVCommandDelegateImpl (GoogleMapsPlugin)
-- (void)hookSendPluginResult:(CDVPluginResult*)result callbackId:(NSString*)callbackId;
 @end
 
 //

--- a/src/ios/GoogleMaps/PluginUtil.m
+++ b/src/ios/GoogleMaps/PluginUtil.m
@@ -104,28 +104,7 @@
   return self;
 }
 
-
 @end
-
-
-/*
-@implementation CDVCommandDelegateImpl (GoogleMapsPlugin)
-
-- (void)hookSendPluginResult:(CDVPluginResult*)result callbackId:(NSString*)callbackId {
-
-  NSRange pos = [callbackId rangeOfString:@"://"];
-  if (pos.location == NSNotFound) {
-    [self sendPluginResult:result callbackId:callbackId];
-  } else {
-    NSArray *tmp = [callbackId componentsSeparatedByString:@"://"];
-    NSString *pluginName = [tmp objectAtIndex:0];
-    CDVPlugin<IPluginProtocol> *plugin = [self getCommandInstance:pluginName];
-    [plugin onHookedPluginResult:result callbackId:callbackId];
-  }
-
-}
-@end
-*/
 
 static char CAAnimationGroupBlockKey;
 @implementation CAAnimationGroup (Blocks)


### PR DESCRIPTION
I made these changes inline from an older version of Gmaps and made an effort not to overwrite any other changes, but should have a second pair of eyes to look over.

Only `CDVCommandDelegateImpl` usages should have changed in this PR.

`PluginUtil` declared a method that used `CDVCommandDelegateImpl` but the implementation was commented out, so both the commented out code and header declaration was removed.

Areas where `self.commandDelegate` was simply used, I removed the `CDVCommandDelegateImpl*` cast, as these objects are simply a `CDVCommandDelegate` protocol object, it doesn't need to be tied to the private implementation object.

In areas where they create a local variable, `id<CDVCommandDelegate>` is used to replace the type, as this is the proper way to reference protocol types and I removed any `CDVCommandDelegateImpl*` casting. I suspect the original author didn't understand how to use protocol objects is why they ended up casting to a private implementation type.

This is required for Cordova iOS 7 support because the iOS 7 framework removes public access to the implementation API.

Cross-Ref: https://totalpave.atlassian.net/browse/TP-2771