### PR TITLE
fix(TP-2847): key cannot be nil

### DIFF
--- a/src/ios/GoogleMaps/PluginTotalPaveTileLayer.m
+++ b/src/ios/GoogleMaps/PluginTotalPaveTileLayer.m
@@ -110,19 +110,19 @@ NSString * const PROPERTY_PREFIX = @"totalpavetilelayer_property";
     }];
 }
 
-- (void)pluginUnload {
-    NSArray *keys = [self.mapCtrl.objects allKeys];
-    NSString *key;
+- (void) pluginUnload {
+    NSArray* keys = [self.mapCtrl.objects allKeys];
     for (int i = 0; i < [keys count]; i++) {
-        key = [keys objectAtIndex:i];
+        NSString* key = [keys objectAtIndex:i];
         if ([key hasPrefix:PREFIX]) {
             key = [key stringByReplacingOccurrencesOfString:@"_property" withString:@""];
-            TotalPaveTileProvider *provider = (TotalPaveTileProvider *)[self.mapCtrl.objects objectForKey:key];
+            TotalPaveTileProvider* provider = (TotalPaveTileProvider*)[self.mapCtrl.objects objectForKey:key];
             provider.map = nil;
             provider = nil;
         }
+
+        [self.mapCtrl.objects removeObjectForKey:key];
     }
-    [self.mapCtrl.objects removeObjectForKey:key];
 }
 
 - (void)setPluginViewController:(PluginViewController *)viewCtrl {


### PR DESCRIPTION
We were incorrectly using the removeObjectForKey API outside of the loop, thus we were only removing the last key in the list.

In the case where there no keys in the objects map, a crash would occur since key will be nil.

removeObjectForKey usage was moved inside the loop, and NSString* key declaration was also moved inside the loop since it's not used outside of the loop at all.

The key value does change depending on a prefix, however this is a pattern used by all GMap plugin objects. Therefore without fully understanding the rationale, I've kept this pattern.
