### PR TITLE
Totalpave/feat/add tile layer scale map

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -130,7 +130,7 @@
     <engine name="apple-ios" version=">=10.0.0" />
   </engines>
 
-  <dependency id="@totalpave/cordova-plugin-tilegen" version="0.3.13" />
+  <dependency id="@totalpave/cordova-plugin-tilegen" version="0.3.15" />
 
   <!-- android -->
   <platform name="android">

--- a/src/android/plugin/google/maps/PluginTotalPaveTileLayer.java
+++ b/src/android/plugin/google/maps/PluginTotalPaveTileLayer.java
@@ -80,8 +80,8 @@ public class PluginTotalPaveTileLayer extends MyPlugin implements MyPluginInterf
             return;
         }
 
-        if (!opts.has("scale")) {
-            callbackContext.error("scale is required.");
+        if (!opts.has("scaleMap")) {
+            callbackContext.error("scaleMap is required.");
             return;
         }
 
@@ -93,7 +93,7 @@ public class PluginTotalPaveTileLayer extends MyPlugin implements MyPluginInterf
                     opts.getString("dbPath"),
                     opts.getString("selectQuery"),
                     opts.getString("reloadSelectQuery"),
-                    opts.getJSONArray("scale")
+                    opts.getJSONObject("scaleMap")
                 );
             }
             catch (Exception ex) {

--- a/src/ios/GoogleMaps/PluginTotalPaveTileLayer.m
+++ b/src/ios/GoogleMaps/PluginTotalPaveTileLayer.m
@@ -39,10 +39,10 @@ NSString * const PROPERTY_PREFIX = @"totalpavetilelayer_property";
         return;
     }
 
-    NSArray* scale = [opts valueForKey:@"scale"];
-    if ([scale isEqual:[NSNull null]] || scale == nil) {
+    NSObject* scaleMap = [opts valueForKey:@"scaleMap"];
+    if ([scaleMap isEqual:[NSNull null]] || scaleMap == nil) {
         [self.commandDelegate
-            sendPluginResult: [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Scale is required."]
+            sendPluginResult: [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"scaleMap is required."]
             callbackId:command.callbackId
         ];
         return;
@@ -50,7 +50,7 @@ NSString * const PROPERTY_PREFIX = @"totalpavetilelayer_property";
     
     [self.commandDelegate runInBackground:^{
         NSError* error;
-        TotalPaveTileProvider* provider = [[TotalPaveTileProvider alloc] initWithDB:dbPath selectQuery:selectQuery reloadSelectQuery:reloadSelectQuery scale:scale error:&error];
+        TotalPaveTileProvider* provider = [[TotalPaveTileProvider alloc] initWithDB:dbPath selectQuery:selectQuery reloadSelectQuery:reloadSelectQuery scaleMap:scaleMap error:&error];
         if (![error isEqual:[NSNull null]] && error != nil) {
             [self.commandDelegate
                 sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]]

--- a/src/ios/GoogleMaps/PluginTotalPaveTileLayer.m
+++ b/src/ios/GoogleMaps/PluginTotalPaveTileLayer.m
@@ -39,7 +39,7 @@ NSString * const PROPERTY_PREFIX = @"totalpavetilelayer_property";
         return;
     }
 
-    NSObject* scaleMap = [opts valueForKey:@"scaleMap"];
+    NSDictionary* scaleMap = [opts valueForKey:@"scaleMap"];
     if ([scaleMap isEqual:[NSNull null]] || scaleMap == nil) {
         [self.commandDelegate
             sendPluginResult: [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"scaleMap is required."]

--- a/src/ios/GoogleMaps/TotalPaveTileProvider.h
+++ b/src/ios/GoogleMaps/TotalPaveTileProvider.h
@@ -2,7 +2,7 @@
 
 @interface TotalPaveTileProvider : GMSSyncTileLayer
 
-- (id _Nonnull)initWithDB:(NSString *_Nonnull)dbName selectQuery:(NSString *_Nonnull)selectQuery reloadSelectQuery:(NSString *_Nonnull)reloadSelectQuery scale:(NSArray*_Nonnull)scale error:(NSError*_Nonnull*_Nonnull)error;
+- (id _Nonnull)initWithDB:(NSString *_Nonnull)dbName selectQuery:(NSString *_Nonnull)selectQuery reloadSelectQuery:(NSString *_Nonnull)reloadSelectQuery scaleMap:(NSDictionary*_Nonnull)scaleMap error:(NSError*_Nonnull*_Nonnull)error;
 - (void)reload:(NSError*_Nonnull*_Nonnull)error;
 - (void)reload:(NSError*_Nonnull*_Nonnull)error ids:(NSArray*_Nonnull)ids;
 - (void)reset;

--- a/src/ios/GoogleMaps/TotalPaveTileProvider.mm
+++ b/src/ios/GoogleMaps/TotalPaveTileProvider.mm
@@ -3,17 +3,17 @@
 #import <tilegen/tilegen.h>
 
 @implementation TotalPaveTileProvider {
-    NSArray* $scale;
+    NSDictionary* $scaleMap;
     TPITilegenLogger* $logger;
     TPITilegenGeneratorSettings* $settings;
 }
 
 NSString* const LIB_TILE_GEN_DOMAIN = @"TotalPaveTileProviderLibTileGen";
 
-- (id)initWithDB:(NSString *)dbPathStr selectQuery:(NSString *)selectQuery reloadSelectQuery:(NSString *)reloadSelectQuery scale:(NSArray*)scale error:(NSError*_Nonnull*_Nonnull) error {
+- (id)initWithDB:(NSString *)dbPathStr selectQuery:(NSString *)selectQuery reloadSelectQuery:(NSString *)reloadSelectQuery scaleMap:(NSDictionary*)scaleMap error:(NSError*_Nonnull*_Nonnull) error {
     self = [super init];
     
-    $scale = scale;
+    $scaleMap = scaleMap;
     
     $logger = [[TPITilegenLogger alloc] init:@"TotalPaveTileProvider"];
     [TPITilegenLogger setActiveLogger: $logger];
@@ -45,26 +45,32 @@ NSString* const LIB_TILE_GEN_DOMAIN = @"TotalPaveTileProviderLibTileGen";
     [builder setTileSize: 512];
     [builder setZoomModifier: 0.2f];
     [builder setZoomModifierThreshold: 16];
+    
+//    NSEnumerator* enumerator = [$scaleMap keyEnumerator];
+    [$scaleMap enumerateKeysAndObjectsUsingBlock:^(id  _Nonnull key, id  _Nonnull obj, BOOL * _Nonnull stop) {
+        NSString* scaleID = key;
+        NSArray* scale = obj;
         
-    for (NSUInteger i = 0, length = scale.count; i < length; ++i) {
-        NSDictionary* item = scale[i];
-        
-        NSNumber* ohigh = [item valueForKey:@"high"];
-        double high = std::numeric_limits<double>::infinity();
-        if (![ohigh isEqual:[NSNull null]]) {
-            high = [ohigh doubleValue];
+        for (NSUInteger i = 0, length = scale.count; i < length; ++i) {
+            NSDictionary* item = scale[i];
+            
+            NSNumber* ohigh = [item valueForKey:@"high"];
+            double high = std::numeric_limits<double>::infinity();
+            if (![ohigh isEqual:[NSNull null]]) {
+                high = [ohigh doubleValue];
+            }
+            
+            TPITilegenScaleItem* scaleItem = [
+                [TPITilegenScaleItem alloc]
+                initLow: [(NSNumber*)[item valueForKey:@"low"] doubleValue]
+                high: high
+                stroke: [(NSNumber*)[item valueForKey:@"stroke"] unsignedIntValue]
+                fill: [(NSNumber*)[item valueForKey:@"fill"] unsignedIntValue]
+            ];
+            
+            [builder addScaleItem: [[NSNumber alloc] initWithLong: [scaleID integerValue]] item: scaleItem];
         }
-        
-        TPITilegenScaleItem* scaleItem = [
-            [TPITilegenScaleItem alloc]
-            initLow: [(NSNumber*)[item valueForKey:@"low"] doubleValue]
-            high: high
-            stroke: [(NSNumber*)[item valueForKey:@"stroke"] unsignedIntValue]
-            fill: [(NSNumber*)[item valueForKey:@"fill"] unsignedIntValue]
-        ];
-        
-        [builder addScaleItem: scaleItem];
-    }
+    }];
     
     $settings = [builder build];
     [self $load:error];

--- a/src/ios/GoogleMaps/TotalPaveTileProvider.mm
+++ b/src/ios/GoogleMaps/TotalPaveTileProvider.mm
@@ -46,7 +46,6 @@ NSString* const LIB_TILE_GEN_DOMAIN = @"TotalPaveTileProviderLibTileGen";
     [builder setZoomModifier: 0.2f];
     [builder setZoomModifierThreshold: 16];
     
-//    NSEnumerator* enumerator = [$scaleMap keyEnumerator];
     [$scaleMap enumerateKeysAndObjectsUsingBlock:^(id  _Nonnull key, id  _Nonnull obj, BOOL * _Nonnull stop) {
         NSString* scaleID = key;
         NSArray* scale = obj;

--- a/www/Map.js
+++ b/www/Map.js
@@ -1242,30 +1242,64 @@ Map.prototype.addTotalPaveTileLayer = function(totalPaveTileLayerOptions, callba
     throw new Error('totalPaveTileLayerOptions.reloadSelectQuery is required. Should be the same as selectQuery, except with a WHERE id IN (:ids) condition.');
   }
 
-  if (!totalPaveTileLayerOptions.scale || !(totalPaveTileLayerOptions.scale instanceof Array) || totalPaveTileLayerOptions.scale.length === 0) {
-    throw new Error('totalPaveTileLayerOptions.scale is required. Array of {low: number, high: number, stroke: hex color string, fill: hex color string}. low and high are used with the select query value.');
+  if (totalPaveTileLayerOptions.scale && totalPaveTileLayerOptions.scaleMap) {
+    throw new Error('both scale and scaleMap is defined. This is not a supported configuration. Preferably use scaleMap instead.');
   }
 
-  for (var i = 0, items = totalPaveTileLayerOptions.scale, length = items.length; i < length - 1; ++i) {
-    var item = items[i];
-    if (typeof item !== 'object') {
-      throw new Error('totalPaveTileLayerOptions.scale[x] must be an Object: {low: floating number, high: floating number, fill: RGBA numerical hex color code, stroke: RGBA numberical hex color code}');
+  if (!totalPaveTileLayerOptions.scale && !totalPaveTileLayerOptions.scaleMap) {
+    throw new Error('Neither scale or scaleMap is defined. One is required, preferably scaleMap');
+  }
+  
+  let isUsingScaleMap = false;
+  if (totalPaveTileLayerOptions.scaleMap) {
+    isUsingScaleMap = true;
+  }
+
+  if (totalPaveTileLayerOptions.scale && !(totalPaveTileLayerOptions.scale instanceof Array) || totalPaveTileLayerOptions.scale.length === 0) {
+    throw new Error('Invalid state. Scale expects Array of {low: number, high: number, stroke: hex color string, fill: hex color string}. low and high are used with the select query value.');
+  }
+
+  if (totalPaveTileLayerOptions.scale) {
+    if (!isUsingScaleMap) {
+      // Migrate scale to scaleMap for backwards compatibility
+      totalPaveTileLayerOptions.scaleMap = {
+        '0': totalPaveTileLayerOptions.scale
+      };
+      delete totalPaveTileLayerOptions.scale;
     }
-    if (typeof item.low !== 'number') {
-      throw new Error('totalPaveTileLayerOptions.scale[' + i + '].low is required. Floating point number.');
-    }
-    if (typeof item.stroke !== 'number') {
-      throw new Error('totalPaveTileLayerOptions.scale[' + i + '].stroke is required. RGBA Numerical hex color code.');
-    }
-    if (typeof item.fill !== 'number') {
-      throw new Error('totalPaveTileLayerOptions.scale[' + i + '].fill is required. RGBA Numerical hex color code.');
+  }
+
+  for (let x in totalPaveTileLayerOptions.scaleMap) {
+    let scale = totalPaveTileLayerOptions.scaleMap[x];
+
+    if (!(scale instanceof Array) || scale.length === 0) {
+      throw new Error('Invalid state. Scale expects Array of {low: number, high: number, stroke: hex color string, fill: hex color string}. low and high are used with the select query value.');
     }
 
-    if (i === length - 1 && (typeof items[i] !== 'object' || items[i].high !== null)) {
-      throw new Error('totalPaveTileLayerOptions.scale[<last item\'s index>].high must be null.');
-    }
-    else if (typeof items[i] !== 'object' || typeof items[i].high !== 'number') {
-      throw new Error('totalPaveTileLayerOptions.scale[' + i + '].high must be a floating point number.');
+    for (let i = 0; i < scale.length; i++) {
+      let item = scale[i];
+      if (typeof item !== 'object') {
+        throw new Error(`totalPaveTileLayerOptions.scaleMap[${x}][${i}] must be an Object: {low: floating number, high: floating number, fill: RGBA numerical hex color code, stroke: RGBA numberical hex color code}`);
+      }
+      if (typeof item.low !== 'number') {
+        throw new Error(`totalPaveTileLayerOptions.scaleMap[${x}][${i}].low is required. Floating point number.`);
+      }
+      if (typeof item.stroke !== 'number') {
+        throw new Error(`totalPaveTileLayerOptions.scaleMap[${x}][${i}].stroke is required. RGBA Numerical hex color code.`);
+      }
+      if (typeof item.fill !== 'number') {
+        throw new Error(`totalPaveTileLayerOptions.scaleMap[${x}][${i}].fill is required. RGBA Numerical hex color code.`);
+      }
+
+      let isLastScaleItem = i === scale.length - 1;
+      if (isLastScaleItem) {
+        if (item.high !== null && typeof item.high !== 'number') {
+          throw new Error(`totalPaveTileLayerOptions.scaleMap[${x}][${i}].high is required. Must be Floating point number or null`);
+        }
+      }
+      else if (typeof item.high !== 'number') {
+        throw new Error(`totalPaveTileLayerOptions.scaleMap[${x}][${i}].high is required. Floating point number.`);
+      }
     }
   }
 

--- a/www/Map.js
+++ b/www/Map.js
@@ -1261,6 +1261,8 @@ Map.prototype.addTotalPaveTileLayer = function(totalPaveTileLayerOptions, callba
 
   if (totalPaveTileLayerOptions.scale) {
     if (!isUsingScaleMap) {
+      console.warn('Scale is deprecated. Use scaleMap instead');
+      
       // Migrate scale to scaleMap for backwards compatibility
       totalPaveTileLayerOptions.scaleMap = {
         '0': totalPaveTileLayerOptions.scale

--- a/www/Map.js
+++ b/www/Map.js
@@ -1,5 +1,3 @@
-
-
 var utils = require('cordova/utils'),
   cordova_exec = require('cordova/exec'),
   common = require('./Common'),
@@ -1255,8 +1253,12 @@ Map.prototype.addTotalPaveTileLayer = function(totalPaveTileLayerOptions, callba
     isUsingScaleMap = true;
   }
 
-  if (totalPaveTileLayerOptions.scale && !(totalPaveTileLayerOptions.scale instanceof Array) || totalPaveTileLayerOptions.scale.length === 0) {
+  if (totalPaveTileLayerOptions.scale && !(totalPaveTileLayerOptions.scale instanceof Array)) {
     throw new Error('Invalid state. Scale expects Array of {low: number, high: number, stroke: hex color string, fill: hex color string}. low and high are used with the select query value.');
+  }
+
+  if (totalPaveTileLayerOptions.scale && totalPaveTileLayerOptions.scale.length === 0) {
+    throw new Error('Invalid State. Scale expects an array of at least 1 item');
   }
 
   if (totalPaveTileLayerOptions.scale) {


### PR DESCRIPTION
Adds new scaleMap option to allow for providing a set of scales mapped by an identifier.

Deprecate but still support the older `scale` option. Scale option will now map to scaleMap internally for backwards compatibility. It's not supported to use both options at the same time.

Native code only reads `scaleMap`.

